### PR TITLE
Put automatic failover behind an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - In memory cache by default
 - Official support for Redis, MongoDB, SQLite, PostgreSQL and MySQL storage adapters
 - Easily plug in your own or third-party storage adapters
-- If DB connection fails, cache is automatically bypassed
+- If DB connection fails, cache is automatically bypassed ([disabled by default](#optsautomaticfailover))
 - Adds cache support to any existing HTTP code with minimal changes
 - Uses [http-cache-semantics](https://github.com/pornel/http-cache-semantics) internally for HTTP RFC 7234 compliance
 
@@ -133,6 +133,13 @@ Default: `false`
 If set to `false`, after a cached resource's TTL expires it is kept in the cache and will be revalidated on the next request with `If-None-Match`/`If-Modified-Since` headers.
 
 If set to `true` once a cached resource has expired it is deleted and will have to be re-requested.
+
+###### opts.automaticFailover
+
+Type: `boolean`<br>
+Default: `false`
+
+When set to `true`, if the DB connection fails we will automatically fallback to a network request. DB errors will still be emitted to notify you of the problem even though the request callback may succeed.
 
 ##### cb
 

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,8 @@ class CacheableRequest {
 				headers: {},
 				method: 'GET',
 				cache: true,
-				strictTtl: false
+				strictTtl: false,
+				automaticFailover: false
 			}, opts);
 			opts.headers = lowercaseKeys(opts.headers);
 
@@ -124,7 +125,7 @@ class CacheableRequest {
 			this.cache.on('error', err => ee.emit('error', new CacheableRequest.CacheError(err)));
 
 			get(opts).catch(err => {
-				if (!madeRequest) {
+				if (opts.automaticFailover && !madeRequest) {
 					makeRequest(opts);
 				}
 				ee.emit('error', new CacheableRequest.CacheError(err));

--- a/test/cacheable-request-instance.js
+++ b/test/cacheable-request-instance.js
@@ -185,9 +185,11 @@ test.cb('cacheableRequest emits RequestError if request function throws', t => {
 		.on('request', req => req.end());
 });
 
-test.cb('cacheableRequest makes request even if initial DB connection fails', t => {
+test.cb('cacheableRequest makes request even if initial DB connection fails (when opts.automaticFailover is enabled)', t => {
 	const cacheableRequest = new CacheableRequest(request, 'sqlite://non/existent/database.sqlite');
-	cacheableRequest(url.parse(s.url), res => {
+	const opts = url.parse(s.url);
+	opts.automaticFailover = true;
+	cacheableRequest(opts, res => {
 		t.is(res.statusCode, 200);
 		t.end();
 	})
@@ -195,7 +197,7 @@ test.cb('cacheableRequest makes request even if initial DB connection fails', t 
 		.on('request', req => req.end());
 });
 
-test.cb('cacheableRequest makes request even if current DB connection fails', t => {
+test.cb('cacheableRequest makes request even if current DB connection fails (when opts.automaticFailover is enabled)', t => {
 	const cache = {
 		get: () => {
 			throw new Error();
@@ -208,7 +210,9 @@ test.cb('cacheableRequest makes request even if current DB connection fails', t 
 		}
 	};
 	const cacheableRequest = new CacheableRequest(request, cache);
-	cacheableRequest(url.parse(s.url), res => {
+	const opts = url.parse(s.url);
+	opts.automaticFailover = true;
+	cacheableRequest(opts, res => {
 		t.is(res.statusCode, 200);
 		t.end();
 	})


### PR DESCRIPTION
If the DB request fails but we haven't made a web request yet we automatically fall back to making a network request. Basically automatic failover to network if the DB goes down.

In hindsight, that's probably not a sensible default. If your DB goes down you may not want (and probably wont expect) to make HTTP requests. e.g Avoiding API limiting

This functionality is still useful, but probably safer to be explicitly enabled via an option.

e.g:

```js
cacheableRequest({
  hostname: 'google.com',
  automaticFailover: true
});
```