### PR TITLE
Refine interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
-  - '8'
-  - '6'
-  - '4'
-script: npm test
-after_success: npm run coverage
-notifications:
-  email:
-    on_success: never
+  - "8"
+  - "6"
+  - "4"
+cache:
+  directories:
+    - "node_modules"
+install:
+    - npm install -g codecov
+after_script:
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# cacheable-request
+# cacheable-request-adaptable
+
+** A fork from [cacheable-request](https://github.com/lukechilds/cacheable-request) with refined interface to expose internal members. **
 
 > Wrap native HTTP requests with RFC compliant cache support
 
-[![Build Status](https://travis-ci.org/lukechilds/cacheable-request.svg?branch=master)](https://travis-ci.org/lukechilds/cacheable-request)
-[![Coverage Status](https://coveralls.io/repos/github/lukechilds/cacheable-request/badge.svg?branch=master)](https://coveralls.io/github/lukechilds/cacheable-request?branch=master)
-[![npm](https://img.shields.io/npm/dm/cacheable-request.svg)](https://www.npmjs.com/package/cacheable-request)
-[![npm](https://img.shields.io/npm/v/cacheable-request.svg)](https://www.npmjs.com/package/cacheable-request)
+[![Build Status](https://travis-ci.org/roneyrao/cacheable-request-adaptable.svg?branch=master)](https://travis-ci.org/roneyrao/cacheable-request-adaptable)
+[![codecov](https://codecov.io/gh/roneyrao/cacheable-request-adaptable/branch/master/graph/badge.svg)](https://codecov.io/gh/roneyrao/cacheable-request-adaptable)
+[![npm](https://img.shields.io/npm/dm/cacheable-request-adaptable.svg)](https://www.npmjs.com/package/cacheable-request-adaptable)
+[![npm](https://img.shields.io/npm/v/cacheable-request-adaptable.svg)](https://www.npmjs.com/package/cacheable-request-adaptable)
 
 [RFC 7234](http://httpwg.org/specs/rfc7234.html) compliant HTTP caching for native Node.js HTTP/HTTPS requests. Caching works out of the box in memory or is easily pluggable with a wide range of storage adapters.
 
@@ -29,14 +31,14 @@
 ## Install
 
 ```shell
-npm install --save cacheable-request
+npm install --save cacheable-request-adaptable
 ```
 
 ## Usage
 
 ```js
 const http = require('http');
-const CacheableRequest = require('cacheable-request');
+const CacheableRequest = require('cacheable-request-adaptable');
 
 // Then instead of
 const req = http.request('http://example.com', cb);
@@ -44,7 +46,9 @@ req.end();
 
 // You can do
 const cacheableRequest = new CacheableRequest(http.request);
-const cacheReq = cacheableRequest('http://example.com', cb);
+// its members such as store, CachePolicy, namespace can be adjusted here.
+const request = cacheableRequest.createRequest();
+const cacheReq = request('http://example.com', cb);
 cacheReq.on('request', req => req.end());
 // Future requests to 'example.com' will be returned from cache if still valid
 
@@ -55,7 +59,7 @@ const cacheableRequest = new CacheableRequest(electron.net);
 
 ## Storage Adapters
 
-`cacheable-request` uses [Keyv](https://github.com/lukechilds/keyv) to support a wide range of storage adapters.
+`cacheable-request-adaptable` uses [Keyv](https://github.com/lukechilds/keyv) to support a wide range of storage adapters.
 
 For example, to use Redis as a cache backend, you just need to install the official Redis Keyv storage adapter:
 
@@ -169,7 +173,7 @@ Errors emitted here will be an instance of `CacheableRequest.RequestError` or `C
 To properly handle all error scenarios you should use the following pattern:
 
 ```js
-cacheableRequest('example.com', cb)
+cacheableRequest.createRequest()('example.com', cb)
   .on('error', err => {
     if (err instanceof CacheableRequest.CacheError) {
       handleCacheError(err); // Cache error
@@ -183,7 +187,7 @@ cacheableRequest('example.com', cb)
   });
 ```
 
-**Note:** Database connection errors are emitted here, however `cacheable-request` will attempt to re-request the resource and bypass the cache on a connection error. Therefore a database connection error doesn't necessarily mean the request won't be fulfilled.
+**Note:** Database connection errors are emitted here, however `cacheable-request-adaptable` will attempt to re-request the resource and bypass the cache on a connection error. Therefore a database connection error doesn't necessarily mean the request won't be fulfilled.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cacheable-request-adaptable
 
-** A fork from [cacheable-request](https://github.com/lukechilds/cacheable-request) with refined interface to expose internal members. **
+**A fork from [cacheable-request](https://github.com/lukechilds/cacheable-request) with refined interface to expose internal members. such as Cache, cachePolicy**
 
 > Wrap native HTTP requests with RFC compliant cache support
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cacheable-request-adaptable
 
-**A fork from [cacheable-request](https://github.com/lukechilds/cacheable-request) with refined interface to expose internal members. such as Cache, cachePolicy**
+**A fork from [cacheable-request](https://github.com/lukechilds/cacheable-request) with refined interface to expose internal members, such as Cache, cachePolicy.**
 
 > Wrap native HTTP requests with RFC compliant cache support
 

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "cacheable-request",
+  "name": "cacheable-request-adaptable",
   "version": "2.1.4",
   "description": "Wrap native HTTP requests with RFC compliant cache support",
   "main": "src/index.js",
   "scripts": {
     "test": "xo && nyc ava",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov"
   },
   "xo": {
     "extends": "xo-lukechilds"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lukechilds/cacheable-request.git"
+    "url": "git+https://github.com/roneyrao/cacheable-request-adaptable.git"
   },
   "keywords": [
     "HTTP",
@@ -26,12 +26,12 @@
     "7234",
     "compliant"
   ],
-  "author": "Luke Childs <lukechilds123@gmail.com> (http://lukechilds.co.uk)",
+  "author": "Roney Rao",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/lukechilds/cacheable-request/issues"
+    "url": "https://github.com/roneyrao/cacheable-request-adaptable/issues"
   },
-  "homepage": "https://github.com/lukechilds/cacheable-request",
+  "homepage": "https://github.com/roneyrao/cacheable-request-adaptable",
   "dependencies": {
     "clone-response": "1.0.2",
     "get-stream": "3.0.0",
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@keyv/sqlite": "^1.2.6",
     "ava": "^0.25.0",
-    "coveralls": "^3.0.0",
     "create-test-server": "^2.0.0",
     "delay": "^2.0.0",
     "eslint-config-xo-lukechilds": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Wrap native HTTP requests with RFC compliant cache support",
   "main": "src/index.js",
   "scripts": {
-    "test": "xo && nyc ava",
-    "coverage": "nyc report --reporter=text-lcov"
+    "test": "xo && nyc ava --reporter=text --reporter=lcov",
+    "prepublish": "npm test"
   },
   "xo": {
     "extends": "xo-lukechilds"

--- a/test/cache.js
+++ b/test/cache.js
@@ -103,7 +103,7 @@ test.before('setup', async () => {
 test('Non cacheable responses are not cached', async t => {
 	const endpoint = '/no-store';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponseInt = Number((await cacheableRequestHelper(s.url + endpoint)).body);
@@ -116,7 +116,7 @@ test('Non cacheable responses are not cached', async t => {
 test('Cacheable responses are cached', async t => {
 	const endpoint = '/cache';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
@@ -129,7 +129,7 @@ test('Cacheable responses are cached', async t => {
 test('Cacheable responses have unique cache key', async t => {
 	const endpoint = '/cache';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint + '?foo');
@@ -142,7 +142,7 @@ test('Cacheable responses have unique cache key', async t => {
 test('Setting opts.cache to false bypasses cache for a single request', async t => {
 	const endpoint = '/cache';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 	const opts = url.parse(s.url + endpoint);
 	const optsNoCache = Object.assign({ cache: false }, opts);
@@ -170,7 +170,7 @@ test('TTL is passed to cache', async t => {
 		},
 		delete: store.delete.bind(store)
 	};
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 	const opts = Object.assign({ strictTtl: true }, url.parse(s.url + endpoint));
 
@@ -190,7 +190,7 @@ test('TTL is not passed to cache if strictTtl is false', async t => {
 		},
 		delete: store.delete.bind(store)
 	};
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 	const opts = Object.assign({ strictTtl: false }, url.parse(s.url + endpoint));
 
@@ -202,7 +202,7 @@ test('TTL is not passed to cache if strictTtl is false', async t => {
 test('Stale cache entries with Last-Modified headers are revalidated', async t => {
 	const endpoint = '/last-modified';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
@@ -218,7 +218,7 @@ test('Stale cache entries with Last-Modified headers are revalidated', async t =
 test('Stale cache entries with ETag headers are revalidated', async t => {
 	const endpoint = '/etag';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
@@ -234,7 +234,7 @@ test('Stale cache entries with ETag headers are revalidated', async t => {
 test('Stale cache entries that can\'t be revalidate are deleted from cache', async t => {
 	const endpoint = '/cache-then-no-store-on-revalidate';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
@@ -251,7 +251,7 @@ test('Stale cache entries that can\'t be revalidate are deleted from cache', asy
 test('Response objects have fromCache property set correctly', async t => {
 	const endpoint = '/cache';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const response = await cacheableRequestHelper(s.url + endpoint);
@@ -264,7 +264,7 @@ test('Response objects have fromCache property set correctly', async t => {
 test('Revalidated responses that are re-cached return 304 but 200 on subsequent cache responses', async t => {
 	const endpoint = '/etag-cache-1s';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
@@ -283,7 +283,7 @@ test('Revalidated responses that are re-cached return 304 but 200 on subsequent 
 test('Revalidated responses that are modified are passed through', async t => {
 	const endpoint = '/revalidate-modified';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
@@ -298,7 +298,7 @@ test('Revalidated responses that are modified are passed through', async t => {
 test.cb('Undefined callback parameter inside cache logic is handled', t => {
 	const endpoint = '/cache';
 	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
+	const cacheableRequest = new CacheableRequest(request, cache).createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 
 	cacheableRequestHelper(s.url + endpoint).then(() => {
@@ -311,7 +311,7 @@ test.cb('Undefined callback parameter inside cache logic is handled', t => {
 
 test('Keyv cache adapters load via connection uri', async t => {
 	const endpoint = '/cache';
-	const cacheableRequest = new CacheableRequest(request, 'sqlite://test/testdb.sqlite');
+	const cacheableRequest = new CacheableRequest(request, 'sqlite://test/testdb.sqlite').createRequest();
 	const cacheableRequestHelper = promisify(cacheableRequest);
 	const db = new sqlite3.Database('test/testdb.sqlite');
 	const query = pify(db.all).bind(db);


### PR DESCRIPTION
1. Expose CacheableRequest instance itself instead of return a request function.
2. Expose CachePolicy and allow being passed in.