### PR TITLE
fix: request args treatment should be consistent with http.request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,14 @@ class CacheableRequest {
 			opts.headers = lowercaseKeys(opts.headers);
 
 			const ee = new EventEmitter();
-			const key = `${opts.method}:${normalizeUrl(urlLib.format(url))}`;
+			const normalizedUrlString = normalizeUrl(
+				urlLib.format(url),
+				{
+					stripWWW: false,
+					removeTrailingSlash: false
+				}
+			);
+			const key = `${opts.method}:${normalizedUrlString}`;
 			let revalidate = false;
 			let madeRequest = false;
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,21 +27,30 @@ class CacheableRequest {
 
 	createCacheableRequest(request) {
 		return (opts, cb) => {
+			let url;
 			if (typeof opts === 'string') {
-				opts = urlLib.parse(opts);
+				url = normalizeUrlObject(urlLib.parse(opts));
+				opts = {};
+			} else if (opts instanceof urlLib.URL) {
+				url = normalizeUrlObject(urlLib.parse(opts.toString()));
+				opts = {};
+			} else {
+				const [pathname, ...search] = (opts.path || '').split('?');
+				url = normalizeUrlObject({ ...opts, pathname, search: search.join('?') });
 			}
-			opts = Object.assign({
+			opts = {
 				headers: {},
 				method: 'GET',
 				cache: true,
 				strictTtl: false,
-				automaticFailover: false
-			}, opts);
+				automaticFailover: false,
+				...opts,
+				...urlObjectToRequestOptions(url)
+			};
 			opts.headers = lowercaseKeys(opts.headers);
 
 			const ee = new EventEmitter();
-			const url = normalizeUrl(urlLib.format(opts));
-			const key = `${opts.method}:${url}`;
+			const key = `${opts.method}:${normalizeUrl(urlLib.format(url))}`;
 			let revalidate = false;
 			let madeRequest = false;
 
@@ -149,6 +158,32 @@ class CacheableRequest {
 			return ee;
 		};
 	}
+}
+
+function urlObjectToRequestOptions(url) {
+	const options = { ...url };
+	options.path = `${url.pathname || '/'}${url.search || ''}`;
+	delete options.pathname;
+	delete options.search;
+	return options;
+}
+
+function normalizeUrlObject(url) {
+	// If url was parsed by url.parse or new URL:
+	// - hostname will be set
+	// - host will be hostname[:port]
+	// - port will be set if it was explicit in the parsed string
+	// Otherwise, url was from request options:
+	// - hostname or host may be set
+	// - host shall not have port encoded
+	return {
+		protocol: url.protocol,
+		auth: url.auth,
+		hostname: url.hostname || url.host || 'localhost',
+		port: url.port,
+		pathname: url.pathname,
+		search: url.search
+	};
 }
 
 CacheableRequest.RequestError = class extends Error {

--- a/test/cacheable-request-instance.js
+++ b/test/cacheable-request-instance.js
@@ -42,6 +42,15 @@ test.cb('cacheableRequest accepts url as string', t => {
 	}).on('request', req => req.end());
 });
 
+test.cb('cacheableRequest accepts url as URL', t => {
+	const cacheableRequest = new CacheableRequest(request);
+	cacheableRequest(new url.URL(s.url), async response => {
+		const body = await getStream(response);
+		t.is(body, 'hi');
+		t.end();
+	}).on('request', req => req.end());
+});
+
 test.cb('cacheableRequest handles no callback parameter', t => {
 	const cacheableRequest = new CacheableRequest(request);
 	cacheableRequest(url.parse(s.url)).on('request', req => {


### PR DESCRIPTION
- adds support for URL instances being passed to request
- when request argument is an object, normalize it according to
  the options accepted by http.request instead of url.format

fixes:
- https://github.com/sindresorhus/got/pull/519
- https://github.com/sindresorhus/got/pull/487

cc @sindresorhus 