### PR TITLE
Uses old cache policy when response is not modified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ class CacheableRequest {
 						if (!revalidatedPolicy.modified) {
 							const headers = revalidatedPolicy.policy.responseHeaders();
 							response = new Response(response.statusCode, headers, revalidate.body, revalidate.url);
-							response.cachePolicy = revalidatedPolicy.policy;
+							response.cachePolicy = CachePolicy.fromObject(revalidate.cachePolicy);
 							response.fromCache = true;
 						}
 					}


### PR DESCRIPTION
Old cache policy should be used when revalidated response is not modified. It does not make sense to use revalidated policy as the response is not modified at all.