### PR TITLE
fix: Don't cache incomplete response when request is aborted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,14 @@ class CacheableRequest {
 			const key = `${opts.method}:${normalizedUrlString}`;
 			let revalidate = false;
 			let madeRequest = false;
+			let requestErrored = false;
+			let requestErrorCallback;
+			const requestErrorPromise = new Promise(resolve => {
+				requestErrorCallback = () => {
+					requestErrored = true;
+					resolve();
+				};
+			});
 
 			const makeRequest = opts => {
 				madeRequest = true;
@@ -89,7 +97,18 @@ class CacheableRequest {
 
 						(async () => {
 							try {
-								const body = await getStream.buffer(response);
+								const bodyPromise = getStream.buffer(response);
+
+								await Promise.race([
+									requestErrorPromise,
+									new Promise(resolve => response.once('end', resolve))
+								]);
+
+								if (requestErrored) {
+									return;
+								}
+
+								const body = await bodyPromise;
 
 								const value = {
 									cachePolicy: response.cachePolicy.toObject(),
@@ -126,6 +145,8 @@ class CacheableRequest {
 
 				try {
 					const req = request(opts, handler);
+					req.once('error', requestErrorCallback);
+					req.once('abort', requestErrorCallback);
 					ee.emit('request', req);
 				} catch (err) {
 					ee.emit('error', new CacheableRequest.RequestError(err));

--- a/src/index.js
+++ b/src/index.js
@@ -63,17 +63,19 @@ class CacheableRequest {
 			const key = `${opts.method}:${normalizedUrlString}`;
 			let revalidate = false;
 			let madeRequest = false;
-			let requestErrored = false;
-			let requestErrorCallback;
-			const requestErrorPromise = new Promise(resolve => {
-				requestErrorCallback = () => {
-					requestErrored = true;
-					resolve();
-				};
-			});
 
 			const makeRequest = opts => {
 				madeRequest = true;
+				let requestErrored = false;
+				let requestErrorCallback;
+
+				const requestErrorPromise = new Promise(resolve => {
+					requestErrorCallback = () => {
+						requestErrored = true;
+						resolve();
+					};
+				});
+
 				const handler = response => {
 					if (revalidate && !opts.forceRefresh) {
 						response.status = response.statusCode;

--- a/test/cacheable-request-instance.js
+++ b/test/cacheable-request-instance.js
@@ -195,6 +195,43 @@ test.cb('cacheableRequest emits RequestError if request function throws', t => {
 		.on('request', req => req.end());
 });
 
+test.cb('cacheableRequest does not cache response if request is aborted', t => {
+	/* eslint-disable max-nested-callbacks */
+	// eslint-disable-next-line promise/prefer-await-to-then
+	createTestServer().then(s => {
+		s.get('/delay', (req, res) => {
+			res.setHeader('cache-control', 'max-age=60');
+			res.write('h');
+			setTimeout(() => {
+				res.end('i');
+			}, 50);
+		});
+
+		const cacheableRequest = new CacheableRequest(request);
+		const opts = url.parse(s.url);
+		opts.path = '/delay';
+		cacheableRequest(opts)
+			.on('request', req => {
+				req.end();
+
+				setTimeout(() => {
+					req.abort();
+				}, 20);
+
+				setTimeout(() => {
+					cacheableRequest(opts, async response => {
+						t.is(response.fromCache, false);
+
+						const body = await getStream(response);
+						t.is(body, 'hi');
+						t.end();
+					}).on('request', req => req.end());
+				}, 100);
+			});
+	});
+	/* eslint-enable max-nested-callbacks */
+});
+
 test.cb('cacheableRequest makes request even if initial DB connection fails (when opts.automaticFailover is enabled)', t => {
 	const cacheableRequest = new CacheableRequest(request, 'sqlite://non/existent/database.sqlite');
 	const opts = url.parse(s.url);

--- a/test/cacheable-request-instance.js
+++ b/test/cacheable-request-instance.js
@@ -195,11 +195,47 @@ test.cb('cacheableRequest emits RequestError if request function throws', t => {
 		.on('request', req => req.end());
 });
 
-test.cb('cacheableRequest does not cache response if request is aborted', t => {
+test.cb('cacheableRequest does not cache response if request is aborted before receiving first byte of response', t => {
 	/* eslint-disable max-nested-callbacks */
 	// eslint-disable-next-line promise/prefer-await-to-then
 	createTestServer().then(s => {
-		s.get('/delay', (req, res) => {
+		s.get('/delay-start', (req, res) => {
+			setTimeout(() => {
+				res.setHeader('cache-control', 'max-age=60');
+				res.end('hi');
+			}, 50);
+		});
+
+		const cacheableRequest = new CacheableRequest(request);
+		const opts = url.parse(s.url);
+		opts.path = '/delay-start';
+		cacheableRequest(opts)
+			.on('request', req => {
+				req.end();
+
+				setTimeout(() => {
+					req.abort();
+				}, 20);
+
+				setTimeout(() => {
+					cacheableRequest(opts, async response => {
+						t.is(response.fromCache, false);
+
+						const body = await getStream(response);
+						t.is(body, 'hi');
+						t.end();
+					}).on('request', req => req.end());
+				}, 100);
+			});
+	});
+	/* eslint-enable max-nested-callbacks */
+});
+
+test.cb('cacheableRequest does not cache response if request is aborted after receiving part of the response', t => {
+	/* eslint-disable max-nested-callbacks */
+	// eslint-disable-next-line promise/prefer-await-to-then
+	createTestServer().then(s => {
+		s.get('/delay-partial', (req, res) => {
 			res.setHeader('cache-control', 'max-age=60');
 			res.write('h');
 			setTimeout(() => {
@@ -209,7 +245,7 @@ test.cb('cacheableRequest does not cache response if request is aborted', t => {
 
 		const cacheableRequest = new CacheableRequest(request);
 		const opts = url.parse(s.url);
-		opts.path = '/delay';
+		opts.path = '/delay-partial';
 		cacheableRequest(opts)
 			.on('request', req => {
 				req.end();


### PR DESCRIPTION
Aborting a request while downloading the response caused an incomplete response to be cached.

I found this issue using Got's timeout option. Here's the related ticket: https://github.com/sindresorhus/got/issues/666