### PR TITLE
Prevents caching of 304 responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ class CacheableRequest {
 					}
 
 					let clonedResponse;
-					if (opts.cache && response.cachePolicy.storable() && (!response.fromCache || revalidate.statusCode != 304)) {
+					if (opts.cache && response.cachePolicy.storable() && (!response.fromCache || revalidate.statusCode !== 304)) {
 						clonedResponse = cloneResponse(response);
 
 						(async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ class CacheableRequest {
 					}
 
 					let clonedResponse;
-					if (opts.cache && response.cachePolicy.storable()) {
+					if (opts.cache && response.cachePolicy.storable() && (!response.fromCache || revalidate.statusCode != 304)) {
 						clonedResponse = cloneResponse(response);
 
 						(async () => {


### PR DESCRIPTION
Revalidated responses have empty body and they get cached sometimes. This fix prevents that.