### PR TITLE
refactor: Ensure request error callback runs only once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,10 @@ class CacheableRequest {
 
 				const requestErrorPromise = new Promise(resolve => {
 					requestErrorCallback = () => {
-						requestErrored = true;
-						resolve();
+						if (!requestErrored) {
+							requestErrored = true;
+							resolve();
+						}
 					};
 				});
 


### PR DESCRIPTION
The `requestErrorCallback` can be called twice in case the request is aborted before receiving the first byte of the response, as it will emit both `abort` and `error` events. This PR ensures the logic inside `requestErrorCallback` runs only once.

There's no behavior change as calling `resolve()` after the promise is already resolved is a no-op.

This is just a sanity check to futureproof the code in case more logic is added to `requestErrorCallback` later on.