### PR TITLE
Preserve original status code when returning cached responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ class CacheableRequest {
 						const revalidatedPolicy = CachePolicy.fromObject(revalidate.cachePolicy).revalidatedPolicy(opts, response);
 						if (!revalidatedPolicy.modified) {
 							const headers = revalidatedPolicy.policy.responseHeaders();
-							response = new Response(response.statusCode, headers, revalidate.body, revalidate.url);
+							response = new Response(revalidate.statusCode, headers, revalidate.body, revalidate.url);
 							response.cachePolicy = revalidatedPolicy.policy;
 							response.fromCache = true;
 						}

--- a/test/cache.js
+++ b/test/cache.js
@@ -486,7 +486,9 @@ test('Stale cache entries with ETag headers are revalidated', async t => {
 
 	t.is(cache.size, 1);
 	t.is(firstResponse.statusCode, 200);
-	t.is(secondResponse.statusCode, 304);
+	t.is(secondResponse.statusCode, 200);
+	t.false(firstResponse.fromCache);
+	t.true(secondResponse.fromCache);
 	t.is(firstResponse.body, 'etag');
 	t.is(firstResponse.body, secondResponse.body);
 });

--- a/test/cache.js
+++ b/test/cache.js
@@ -90,19 +90,6 @@ test.before('setup', async () => {
 		res.end(responseBody);
 	});
 
-	s.get('/etag-cache-1s', (req, res) => {
-		res.setHeader('Cache-Control', 'public, max-age=1');
-		res.setHeader('ETag', '33a64df551425fcc55e4d42a148795d9f25f89d4');
-		let responseBody = 'etag-cache-1s';
-
-		if (req.headers['if-none-match'] === '33a64df551425fcc55e4d42a148795d9f25f89d4') {
-			res.statusCode = 304;
-			responseBody = null;
-		}
-
-		res.end(responseBody);
-	});
-
 	let cacheThenNoStoreIndex = 0;
 	s.get('/cache-then-no-store-on-revalidate', (req, res) => {
 		const cc = cacheThenNoStoreIndex === 0 ? 'public, max-age=0' : 'public, no-cache, no-store';
@@ -521,25 +508,6 @@ test('Response objects have fromCache property set correctly', async t => {
 
 	t.false(response.fromCache);
 	t.true(cachedResponse.fromCache);
-});
-
-test('Revalidated responses that are re-cached return 304 but 200 on subsequent cache responses', async t => {
-	const endpoint = '/etag-cache-1s';
-	const cache = new Map();
-	const cacheableRequest = new CacheableRequest(request, cache);
-	const cacheableRequestHelper = promisify(cacheableRequest);
-
-	const firstResponse = await cacheableRequestHelper(s.url + endpoint);
-	await delay(1100);
-	const secondResponse = await cacheableRequestHelper(s.url + endpoint);
-	const thirdResponse = await cacheableRequestHelper(s.url + endpoint);
-
-	t.is(firstResponse.statusCode, 200);
-	t.false(firstResponse.fromCache);
-	t.is(secondResponse.statusCode, 304);
-	t.true(secondResponse.fromCache);
-	t.is(thirdResponse.statusCode, 200);
-	t.true(thirdResponse.fromCache);
 });
 
 test('Revalidated responses that are modified are passed through', async t => {

--- a/test/cache.js
+++ b/test/cache.js
@@ -468,7 +468,9 @@ test('Stale cache entries with Last-Modified headers are revalidated', async t =
 
 	t.is(cache.size, 1);
 	t.is(firstResponse.statusCode, 200);
-	t.is(secondResponse.statusCode, 304);
+	t.is(secondResponse.statusCode, 200);
+	t.false(firstResponse.fromCache);
+	t.true(secondResponse.fromCache);
 	t.is(firstResponse.body, 'last-modified');
 	t.is(firstResponse.body, secondResponse.body);
 });


### PR DESCRIPTION
Potential solution to https://github.com/lukechilds/cacheable-request/issues/28

Recommended by @kornelski.