### PR TITLE
fix: ensure namespace is not twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class CacheableRequest {
 		});
 		
 		if (this.cache.opts.store && this.cache.opts.store.namespace) {
+			this.cache.opts.namespace = this.cache.opts.store.namespace
 			delete this.cache.opts.store.namespace
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,10 @@ class CacheableRequest {
 			store: typeof cacheAdapter !== 'string' && cacheAdapter,
 			namespace: 'cacheable-request'
 		});
+		
+		if (this.cache.opts.store && this.cache.opts.store.namespace) {
+			delete this.cache.opts.store.namespace
+		}
 
 		return this.createCacheableRequest(request);
 	}


### PR DESCRIPTION
Since `store` can be declared as `Keyv` instance, the user can provide a store prefixed with a `namespace`. On the other hand, the library is always adding a namespace, so in case both things are provided, the key associated with the cached items looks like

```
cacheable-request:cacheable-request:GET:https://example.com
```

This PR avoid to write the same namespace prefix twice as part of the key